### PR TITLE
向上アンケートをgoogle form からformspree に変更

### DIFF
--- a/app/only_events/page.js
+++ b/app/only_events/page.js
@@ -1,16 +1,141 @@
-export default function UpdatePage() {
-    return (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '20px' }}>
-            <iframe 
-                src="https://docs.google.com/forms/d/e/1FAIpQLSfAkRiwwYo_uy-YpE4TVXIuuggkTgHURpYBNma3qil_zycqyA/viewform?embedded=true" 
-                width="640" 
-                height="1708" 
-                style={{ border: 'none' }}
-                title="Google Form"
-                allowFullScreen
-            >
-                読み込んでいます…
-            </iframe>
-        </div>
-    );
+'use client';
+
+import React from 'react';
+import { useForm, ValidationError } from '@formspree/react';
+
+const eventOptions = [
+  { value: '', label: 'イベントを選択してください' },
+  { value: 'event1', label: '技育campキャラバン' },
+  { value: 'event2', label: '技育campハッカソン' },
+  { value: 'event3', label: '技育博' },
+  { value: 'event4', label: 'ぼうさいこくたい' },
+  { value: 'other', label: 'その他' },
+];
+
+export default function ContactForm() {
+  const [state, handleSubmit] = useForm("myzdvjdj");
+  if (state.succeeded) {
+    return <p>送信ありがとうございました！</p>;
+  }
+  return (
+    <div style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '100vh'
+    }}>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          maxWidth: 400,
+          width: '100%',
+          padding: 32,
+          border: '2px solid #000',
+          borderRadius: 12,
+        }}
+      >
+        <h2 style={{ textAlign: 'center', marginBottom: 24 }}>システム改善アンケート</h2>
+
+        <label htmlFor="event" style={{ fontWeight: 'bold' }}>参加イベント名<span style={{color:'red'}}> *</span></label>
+        <select
+          id="event"
+          name="event"
+          required
+          defaultValue=""
+          style={{
+            width: '100%',
+            marginBottom: 10,
+            padding: '6px',
+            borderRadius: 6,
+            border: '1px solid #ccc'
+          }}
+        >
+          {eventOptions.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+        <ValidationError prefix="Event" field="event" errors={state.errors} />
+
+        <label htmlFor="name" style={{ fontWeight: 'bold' }}>氏名</label>
+        <input
+          id="name"
+          type="text"
+          name="name"
+          style={{
+            width: '100%',
+            marginBottom: 10,
+            padding: '6px',
+            borderRadius: 6,
+            border: '1px solid #ccc'
+          }}
+        />
+        <ValidationError prefix="Name" field="name" errors={state.errors} />
+
+        <label htmlFor="email" style={{ fontWeight: 'bold' }}>メールアドレス</label>
+        <input
+          id="email"
+          type="email"
+          name="email"
+          style={{
+            width: '100%',
+            marginBottom: 10,
+            padding: '6px',
+            borderRadius: 6,
+            border: '1px solid #ccc'
+          }}
+        />
+        <ValidationError prefix="Email" field="email" errors={state.errors} />
+
+        <label htmlFor="affiliation" style={{ fontWeight: 'bold' }}>所属</label>
+        <textarea
+          id="affiliation"
+          name="affiliation"
+          rows={2}
+          style={{
+            width: '100%',
+            marginBottom: 10,
+            padding: '6px',
+            borderRadius: 6,
+            border: '1px solid #ccc'
+          }}
+        />
+        <ValidationError prefix="Affiliation" field="affiliation" errors={state.errors} />
+
+        <label htmlFor="feedback" style={{ fontWeight: 'bold' }}>ご意見・感想<span style={{color:'red'}}> *</span></label>
+        <textarea
+          id="feedback"
+          name="feedback"
+          required
+          rows={5}
+          style={{
+            width: '100%',
+            marginBottom: 10,
+            padding: '6px',
+            borderRadius: 6,
+            border: '1px solid #ccc'
+          }}
+        />
+        <ValidationError prefix="Feedback" field="feedback" errors={state.errors} />
+
+        <button
+          type="submit"
+          disabled={state.submitting}
+          style={{
+            width: '100%',
+            padding: '10px 0',
+            borderRadius: 6,
+            border: 'none',
+            background: '#1976d2',
+            color: '#fff',
+            fontWeight: 'bold',
+            fontSize: '1rem',
+            cursor: 'pointer',
+            marginTop: 8
+          }}
+        >
+          送信
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "disaster_vulnerability_dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@formspree/react": "^3.0.0",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/supabase-js": "^2.52.0",
@@ -214,6 +215,30 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formspree/core": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@formspree/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-geNlUut5nME1Ztej5Pzx1BrlQ1fFIcJYIqmF+Vm0jaUbpZxjXvt7SDOGeQVkuxn80QJiIHlwBGGjSBFjPX/KDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stripe/stripe-js": "^5.7.0"
+      }
+    },
+    "node_modules/@formspree/react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@formspree/react/-/react-3.0.0.tgz",
+      "integrity": "sha512-8PufBZ4l13VmCp9xTGQXwyF6mZtYSecqgTlFuMo5Fbe4Q6zUk7PMU2uKOwIaytZyTyJgFVCvdbpQElPPBKYNLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formspree/core": "^4.0.0",
+        "@stripe/react-stripe-js": "^3.1.1",
+        "@stripe/stripe-js": "^5.7.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1039,6 +1064,29 @@
       "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
       "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.10.0.tgz",
+      "integrity": "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@formspree/react": "^3.0.0",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/supabase-js": "^2.52.0",


### PR DESCRIPTION
## 🔧 概要（機能名 / 画面名）
システム改善アンケートフォームのUI・項目修正

## 📄 対象ページ・ファイル
- パス: `/only_events`
- 主要ファイル: `app/only_events/page.js`

## 🧾 実装による変化

### Before（任意）
- フォーム項目や必須・任意条件が不明確
- イベント名やご意見・感想の必須指定が未対応

### After（変更点）
- イベント名（プルダウン/必須）、氏名（短文/任意）、メールアドレス（正規/任意）、所属（長文/任意）、ご意見・感想（長文/必須）に修正
- 必須項目にバリデーション追加
- 枠線を黒、中央配置、UI調整

## 🧪 動作確認項目
- [x] UIが正しく表示される
- [x] 必須項目が未入力の場合送信不可
- [x] 任意項目は空欄でも送信可能
- [x] 送信後、完了メッセージ表示
- [x] エラー・警告なし

## 🔍 今後の修正必要性（任意）
- 緊急度: 低  
- イベント名リストの追加・変更
- デザイン微調整

## 📝 その他メモ（任意）
- FormspreeのフォームIDは環境に合わせて変更
- スパム対策や入力チェック強化は今後検討