### PR TITLE
ナビゲーションのフォントサイズを変更

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -31,7 +31,7 @@ export default function Sidebar() {
           { href: "/alert", text: "アラート情報" },
           { href: "/evacuation", text: "避難情報" },
           { href: "/update", text: "更新情報" },
-          { href: "/only_events", text: "システム改善アンケート" },
+          { href: "/only_events", text: "システムに関するアンケート", small: true },
         ];
       } else {
         MenuItems = [
@@ -93,7 +93,7 @@ export default function Sidebar() {
                   key={item.href}
                   href={item.href}
                   onClick={() => setIsOpen(false)}
-                  className="text-lg py-2"
+                  className={`py-2 ${item.small ? "text-sm" : "text-xl"}`}
                 >
                   {item.text}
                 </Link>
@@ -110,7 +110,13 @@ export default function Sidebar() {
       <h1 className="text-2xl font-bold mb-8">CityRiskView</h1>
       <nav className="flex flex-col gap-4">
         {menuItems.map((item) => (
-          <Link key={item.href} href={item.href}>{item.text}</Link>
+          <Link
+            key={item.href}
+            href={item.href}
+            className={item.small ? "text-sm" : "text-xl"}
+          >
+            {item.text}
+          </Link>
         ))}
       </nav>
     </div>


### PR DESCRIPTION
## 🔧 概要（機能名 / 画面名）
サイドバーのメニュー項目のフォントサイズ調整

## 📄 対象ページ・ファイル
- パス: 全ページ（サイドバー共通表示）
- 主要ファイル: `components/Sidebar.js`

## 🧾 実装による変化

### Before（任意）
- 「システムに関するアンケート」以外の項目が `text-lg` で表示されていた
- 「システムに関するアンケート」は `text-sm` で表示されていた

### After（変更点）
- 「システムに関するアンケート」は `text-sm` で表示（小さい文字）
- その他の項目は `text-xl` で表示（より大きい文字）

## 🧪 動作確認項目
- [x] サイドバーの各項目のフォントサイズが意図通り表示される
- [x] クリック時の挙動が正常
- [x] エラー・警告