### PR TITLE
Feature/shelter view manegement

### DIFF
--- a/app/alert/page.js
+++ b/app/alert/page.js
@@ -14,7 +14,7 @@ export default function AlertPage() {
       const { data, error } = await supabase
         .from('ui_adjusting')
         .select('is_adjusting')
-        .eq('screen', 'evacuation')
+        .eq('screen', 'alert')
         .single();
       if (!error && data) setIsAdjusting(data.is_adjusting);
     };

--- a/app/alert/page.js
+++ b/app/alert/page.js
@@ -1,6 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
 // 通知・アラート画面
 
 export default function AlertPage() {
-    return <h2 className="text-xl font-bold">アラート情報（仮）</h2>;
-  }
-  
+  const [isAdjusting, setIsAdjusting] = useState(false);
+
+  useEffect(() => {
+    // Supabaseから調整中状態を取得
+    const fetchAdjusting = async () => {
+      const { data, error } = await supabase
+        .from('ui_adjusting')
+        .select('is_adjusting')
+        .eq('screen', 'evacuation')
+        .single();
+      if (!error && data) setIsAdjusting(data.is_adjusting);
+    };
+    fetchAdjusting();
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold">アラート情報（仮）</h2>
+      {isAdjusting && (
+        <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
+          現在調整中のため、不具合が出る場合があります
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/developer/page.js
+++ b/app/developer/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, Suspense } from "react";
 import { supabase } from "@/lib/supabase";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -21,7 +21,7 @@ const tabs = [
   { key: "release", label: "リリース情報", component: ReleaseTab },
 ];
 
-export default function DeveloperPage() {
+function DeveloperPageInner() {
   const [isDeveloper, setIsDeveloper] = useState(false);
   const [loading, setLoading] = useState(true);
   const [updates, setUpdates] = useState([]);
@@ -160,5 +160,14 @@ export default function DeveloperPage() {
         <ActiveTabComponent updates={updates} logs={systemLogs} />
       </main>
     </div>
+  );
+}
+
+// エクスポート部分を以下のように修正
+export default function DeveloperPage() {
+  return (
+    <Suspense fallback={<div>読み込み中...</div>}>
+      <DeveloperPageInner />
+    </Suspense>
   );
 }

--- a/app/developer/page.js
+++ b/app/developer/page.js
@@ -1,262 +1,92 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import AuthGuard from "@/components/AuthGuard";
+import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useRouter } from "next/navigation";
-import ShelterManagement from "./components/ShelterManagement";
+import { useRouter, useSearchParams } from "next/navigation";
+
+// 各タブ import
+import SheltersTab from "./tabs/SheltersTab";
+import UpdateManagerTab from "./tabs/UpdateManagerTab";
+import LogsTab from "./tabs/LogsTab";
+import DatabaseTab from "./tabs/DatabaseTab";
+import DeploymentTab from "./tabs/DeploymentTab";
+import ReleaseTab from "./tabs/ReleaseTab";
+
+const tabs = [
+  { key: "shelters", label: "避難所管理", component: SheltersTab },
+  { key: "updates", label: "アップデート管理", component: UpdateManagerTab },
+  { key: "logs", label: "システムログ", component: LogsTab },
+  { key: "database", label: "データベース監視", component: DatabaseTab },
+  { key: "deployment", label: "デプロイメント", component: DeploymentTab },
+  { key: "release", label: "リリース情報", component: ReleaseTab },
+];
 
 export default function DeveloperPage() {
-  const [currentView, setCurrentView] = useState("shelters");
-  const [updates, setUpdates] = useState([]);
-  const [systemLogs, setSystemLogs] = useState([]);
   const [isDeveloper, setIsDeveloper] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [updates, setUpdates] = useState([]);
+  const [systemLogs, setSystemLogs] = useState([]);
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentTab = searchParams.get("tab") || "shelters";
 
   useEffect(() => {
     checkDeveloperAccess();
   }, []);
 
   const checkDeveloperAccess = async () => {
-    try {
-      const {
-        data: { user },
-        error,
-      } = await supabase.auth.getUser();
-
-      if (error || !user) {
-        router.push("/login");
-        return;
-      }
-
-      // 開発者権限チェック
-      const developerEmails = ["sudoproject.personal@gmail.com"];
-      if (!developerEmails.includes(user.email)) {
-        alert("開発者権限が必要です");
-        router.push("/admin");
-        return;
-      }
-
-      setIsDeveloper(true);
-      await fetchData();
-    } catch (error) {
-      console.error("Developer access check failed:", error);
-      router.push("/admin");
+    const { data: { user }, error } = await supabase.auth.getUser();
+    if (error || !user) {
+      router.push("/login");
+      return;
     }
+    if (!["sudoproject.personal@gmail.com"].includes(user.email)) {
+      alert("開発者権限が必要です");
+      router.push("/admin");
+      return;
+    }
+    setIsDeveloper(true);
     setLoading(false);
   };
 
-  const fetchData = async () => {
-    await Promise.all([fetchUpdates(), fetchSystemLogs()]);
-  };
+  if (loading) return <div>読み込み中...</div>;
+  if (!isDeveloper) return <div>権限がありません</div>;
 
-  const fetchUpdates = async () => {
-    try {
-      const { data, error } = await supabase
-        .from("developer_updates")
-        .select("*")
-        .order("created_at", { ascending: false });
-
-      if (error) throw error;
-      setUpdates(data || []);
-    } catch (error) {
-      console.error("Error fetching updates:", error);
-    }
-  };
-
-  const fetchSystemLogs = async () => {
-    try {
-      const { data, error } = await supabase
-        .from("system_logs")
-        .select("*")
-        .order("created_at", { ascending: false })
-        .limit(50);
-
-      if (error) throw error;
-      setSystemLogs(data || []);
-    } catch (error) {
-      console.error("Error fetching logs:", error);
-    }
-  };
-
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-    router.push("/login");
-  };
-
-  const renderContent = () => {
-    switch (currentView) {
-      case "shelters":
-        return <ShelterManagement />;
-      case "updates":
-        return <UpdateManager updates={updates} onRefresh={fetchUpdates} />;
-      case "logs":
-        return <SystemLogs logs={systemLogs} />;
-      case "database":
-        return <DatabaseMonitor />;
-      case "deployment":
-        return <DeploymentManager />;
-      case "release":
-        return <GitHubReleaseInfo />;
-      default:
-        return <ShelterManagement />;
-    }
-  };
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-lg">読み込み中...</div>
-      </div>
-    );
-  }
-
-  if (!isDeveloper) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-lg text-red-600">権限がありません</div>
-      </div>
-    );
-  }
+  const ActiveTabComponent = tabs.find(t => t.key === currentTab)?.component || SheltersTab;
 
   return (
     <div className="min-h-screen bg-gray-50">
       {/* ヘッダー */}
       <header className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-6">
-            <h1 className="text-3xl font-bold text-gray-900">開発者管理画面</h1>
-            <div>
-              <button
-                onClick={() => router.push("/admin")}
-                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 mr-4"
-              >
-                管理者画面へ
-              </button>
-              <button
-                onClick={handleLogout}
-                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-              >
-                ログアウト
-              </button>
-            </div>
-          </div>
+        <div className="flex justify-between items-center py-6 px-4">
+          <h1 className="text-3xl font-bold">開発者管理画面</h1>
         </div>
       </header>
 
       {/* タブナビゲーション */}
       <nav className="bg-white border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex space-x-8">
-            {[
-              { key: "shelters", label: "避難所管理" },
-              { key: "release", label: "リリース情報" },
-              { key: "logs", label: "システムログ" },
-              { key: "database", label: "データベース監視" },
-              { key: "deployment", label: "デプロイメント" },
-            ].map((tab) => (
-              <button
-                key={tab.key}
-                onClick={() => setCurrentView(tab.key)}
-                className={`py-4 px-1 border-b-2 font-medium text-sm ${currentView === tab.key
-                    ? "border-blue-500 text-blue-600"
-                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-                  }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
+        <div className="flex space-x-8 px-4">
+          {tabs.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => router.push(`?tab=${tab.key}`)}
+              className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                currentTab === tab.key
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
       </nav>
 
-      {/* メインコンテンツ */}
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        {renderContent()}
+      {/* メイン */}
+      <main className="max-w-7xl mx-auto py-6 px-4">
+        <ActiveTabComponent updates={updates} logs={systemLogs} />
       </main>
-    </div>
-  );
-}
-
-// 他のコンポーネントはここに追加または別ファイルに分離
-function UpdateManager({ updates, onRefresh }) {
-  return (
-    <div className="bg-white shadow rounded-lg p-6">
-      <h2 className="text-lg font-medium mb-4">アップデート管理</h2>
-      <p className="text-gray-500">アップデート管理機能をここに実装</p>
-    </div>
-  );
-}
-
-function SystemLogs({ logs }) {
-  return (
-    <div className="bg-white shadow rounded-lg p-6">
-      <h2 className="text-lg font-medium mb-4">システムログ</h2>
-      <p className="text-gray-500">システムログ表示機能をここに実装</p>
-    </div>
-  );
-}
-
-function DatabaseMonitor() {
-  return (
-    <div className="bg-white shadow rounded-lg p-6">
-      <h2 className="text-lg font-medium mb-4">データベース監視</h2>
-      <p className="text-gray-500">データベース監視機能をここに実装</p>
-    </div>
-  );
-}
-
-function DeploymentManager() {
-  return (
-    <div className="bg-white shadow rounded-lg p-6">
-      <h2 className="text-lg font-medium mb-4">デプロイメント管理</h2>
-      <p className="text-gray-500">デプロイメント管理機能をここに実装</p>
-    </div>
-  );
-}
-
-function GitHubReleaseInfo() {
-  const [release, setRelease] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const fetchRelease = async () => {
-      try {
-        const res = await fetch(
-          "https://api.github.com/repos/s-taku0502/cityriskview/releases/latest"
-        );
-        if (!res.ok) throw new Error("GitHub API error");
-        const data = await res.json();
-        setRelease(data);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchRelease();
-  }, []);
-
-  if (loading) return <div>リリース情報取得中...</div>;
-  if (error) return <div className="text-red-600">エラー: {error}</div>;
-  if (!release) return <div>リリース情報なし</div>;
-
-  return (
-    <div className="bg-white shadow rounded-lg p-6">
-      <h2 className="text-lg font-medium mb-4">最新リリース情報</h2>
-      <p><strong>バージョン:</strong> {release.tag_name}</p>
-      <p><strong>公開日:</strong> {new Date(release.published_at).toLocaleString()}</p>
-      <div className="mt-2 whitespace-pre-line text-gray-700">{release.body}</div>
-      <a
-        href={release.html_url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-      >
-        詳細を見る
-      </a>
     </div>
   );
 }

--- a/app/developer/page.js
+++ b/app/developer/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { supabase } from "@/lib/supabase";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -31,8 +31,18 @@ export default function DeveloperPage() {
 
   const currentTab = searchParams.get("tab") || "shelters";
 
+  // --- UI調整中管理用 ---
+  const [adjustingScreens, setAdjustingScreens] = useState({
+    evacuation: false,
+    stock: false,
+    alert: false,
+  });
+  const [selectedScreen, setSelectedScreen] = useState("evacuation");
+  // --- ここまで ---
+
   useEffect(() => {
     checkDeveloperAccess();
+    fetchAdjustingScreens();
   }, []);
 
   const checkDeveloperAccess = async () => {
@@ -50,6 +60,36 @@ export default function DeveloperPage() {
     setLoading(false);
   };
 
+  const fetchAdjustingScreens = async () => {
+    const { data, error } = await supabase
+      .from('ui_adjusting')
+      .select('screen, is_adjusting');
+    if (!error && data) {
+      const newState = { evacuation: false, stock: false, alert: false };
+      data.forEach(row => {
+        if (row.screen in newState) newState[row.screen] = row.is_adjusting;
+      });
+      setAdjustingScreens(newState);
+    }
+  };
+
+  // --- UI調整中切り替え関数 ---
+  const handleAdjustStart = async () => {
+    await supabase
+      .from('ui_adjusting')
+      .update({ is_adjusting: true })
+      .eq('screen', selectedScreen);
+    fetchAdjustingScreens(); // 状態を再取得
+  };
+  const handleAdjustEnd = async () => {
+    await supabase
+      .from('ui_adjusting')
+      .update({ is_adjusting: false })
+      .eq('screen', selectedScreen);
+    fetchAdjustingScreens(); // 状態を再取得
+  };
+  // --- ここまで ---
+
   if (loading) return <div>読み込み中...</div>;
   if (!isDeveloper) return <div>権限がありません</div>;
 
@@ -63,6 +103,38 @@ export default function DeveloperPage() {
           <h1 className="text-3xl font-bold">開発者管理画面</h1>
         </div>
       </header>
+
+      {/* --- UI調整中管理UI --- */}
+      <section className="bg-yellow-50 border border-yellow-300 rounded p-4 m-4">
+        <div className="flex items-center space-x-4">
+          <span>調整対象画面:</span>
+          <select
+            value={selectedScreen}
+            onChange={e => setSelectedScreen(e.target.value)}
+            className="border rounded px-2 py-1"
+          >
+            <option value="evacuation">/evacuation</option>
+            <option value="stock">/stock</option>
+            <option value="alert">/alert</option>
+          </select>
+          <button
+            onClick={handleAdjustStart}
+            className="bg-orange-500 text-white px-3 py-1 rounded"
+          >
+            調整中
+          </button>
+          <button
+            onClick={handleAdjustEnd}
+            className="bg-green-500 text-white px-3 py-1 rounded"
+          >
+            調整終了
+          </button>
+          <span>
+            現在: {adjustingScreens[selectedScreen] ? "調整中" : "通常"}
+          </span>
+        </div>
+      </section>
+      {/* --- ここまで --- */}
 
       {/* タブナビゲーション */}
       <nav className="bg-white border-b">

--- a/app/developer/tabs/DatabaseTab.js
+++ b/app/developer/tabs/DatabaseTab.js
@@ -1,0 +1,10 @@
+"use client";
+
+export default function DatabaseTab() {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-medium mb-4">データベース監視</h2>
+      <p className="text-gray-500">データベース監視機能をここに実装</p>
+    </div>
+  );
+}

--- a/app/developer/tabs/DeploymentTab.js
+++ b/app/developer/tabs/DeploymentTab.js
@@ -1,0 +1,10 @@
+"use client";
+
+export default function DeploymentTab() {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-medium mb-4">デプロイメント管理</h2>
+      <p className="text-gray-500">デプロイメント管理機能をここに実装</p>
+    </div>
+  );
+}

--- a/app/developer/tabs/LogsTab.js
+++ b/app/developer/tabs/LogsTab.js
@@ -1,0 +1,10 @@
+"use client";
+
+export default function LogsTab({ logs }) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-medium mb-4">システムログ</h2>
+      <p className="text-gray-500">システムログ表示機能をここに実装</p>
+    </div>
+  );
+}

--- a/app/developer/tabs/ReleaseTab.js
+++ b/app/developer/tabs/ReleaseTab.js
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export default function ReleaseTab() {
+  const [release, setRelease] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchRelease = async () => {
+      try {
+        const res = await fetch(
+          "https://api.github.com/repos/s-taku0502/cityriskview/releases/latest"
+        );
+        if (!res.ok) throw new Error("GitHub API error");
+        const data = await res.json();
+        setRelease(data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRelease();
+  }, []);
+
+  if (loading) return <div>リリース情報取得中...</div>;
+  if (error) return <div className="text-red-600">エラー: {error}</div>;
+  if (!release) return <div>リリース情報なし</div>;
+
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-medium mb-4">最新リリース情報</h2>
+      <p><strong>バージョン:</strong> {release.tag_name}</p>
+      <p><strong>公開日:</strong> {new Date(release.published_at).toLocaleString()}</p>
+      <div className="mt-2 whitespace-pre-line text-gray-700">{release.body}</div>
+      <a
+        href={release.html_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        詳細を見る
+      </a>
+    </div>
+  );
+}

--- a/app/developer/tabs/SheltersTab.js
+++ b/app/developer/tabs/SheltersTab.js
@@ -1,0 +1,11 @@
+"use client";
+
+import ShelterManagement from "../components/ShelterManagement";
+
+export default function SheltersTab() {
+  return (
+    <div>
+      <ShelterManagement />
+    </div>
+  );
+}

--- a/app/developer/tabs/UpdateManagerTab.js
+++ b/app/developer/tabs/UpdateManagerTab.js
@@ -1,0 +1,10 @@
+"use client";
+
+export default function UpdateManagerTab({ updates, onRefresh }) {
+  return (
+    <div className="bg-white shadow rounded-lg p-6">
+      <h2 className="text-lg font-medium mb-4">アップデート管理</h2>
+      <p className="text-gray-500">アップデート管理機能をここに実装</p>
+    </div>
+  );
+}

--- a/app/evacuation/page.js
+++ b/app/evacuation/page.js
@@ -7,34 +7,45 @@ import EvacuationMap from './components/EvacuationMap'
 import EvacuationAlert from './components/EvacuationAlert'
 import RouteDisplay from './components/RouteDisplay'
 import EmergencyContacts from './components/EmergencyContacts'
+import { supabase } from '@/lib/supabase'
 
 export default function EvacuationPage() {
   const [currentLocation, setCurrentLocation] = useState(null)
   const [emergencyAlerts, setEmergencyAlerts] = useState([])
   const [loading, setLoading] = useState(true)
   const [currentView, setCurrentView] = useState('map')
-  const router = useRouter()
+  const [isAdjusting, setIsAdjusting] = useState(false)
 
   // 最寄り避難所フックを使用
-  const { 
-    nearestShelter, 
-    allShelters, 
-    loading: shelterLoading, 
-    error: shelterError 
+  const {
+    nearestShelter,
+    allShelters,
+    loading: shelterLoading,
+    error: shelterError
   } = useNearestShelter(currentLocation)
 
   useEffect(() => {
     initializeEvacuation()
+    // Supabaseから調整中状態を取得
+    const fetchAdjusting = async () => {
+      const { data, error } = await supabase
+        .from('ui_adjusting')
+        .select('is_adjusting')
+        .eq('screen', 'evacuation')
+        .single()
+      if (!error && data) setIsAdjusting(data.is_adjusting)
+    }
+    fetchAdjusting()
   }, [])
 
   const initializeEvacuation = async () => {
     try {
       // 現在地取得
       await getCurrentLocation()
-      
+
       // 緊急警報取得
       await fetchEmergencyAlerts()
-      
+
       setLoading(false)
     } catch (error) {
       console.error('避難情報の初期化に失敗:', error)
@@ -152,6 +163,7 @@ export default function EvacuationPage() {
 
   return (
     <div className="min-h-screen bg-gray-100">
+
       {/* 緊急警報 */}
       {emergencyAlerts.length > 0 && (
         <EvacuationAlert alerts={emergencyAlerts} />
@@ -165,7 +177,7 @@ export default function EvacuationPage() {
               <h1 className="text-xl font-bold text-gray-900">避難情報</h1>
               {nearestShelter && (
                 <div className="ml-4 text-sm text-gray-600">
-                  最寄り避難所: {nearestShelter.name} 
+                  最寄り避難所: {nearestShelter.name}
                   ({nearestShelter.distance?.toFixed(1)}km / 徒歩約{nearestShelter.walkingTime}分)
                 </div>
               )}
@@ -180,37 +192,41 @@ export default function EvacuationPage() {
           <nav className="flex space-x-8">
             <button
               onClick={() => setCurrentView('map')}
-              className={`${
-                currentView === 'map'
-                  ? 'border-indigo-500 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
+              className={`${currentView === 'map'
+                ? 'border-indigo-500 text-gray-900'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
             >
               避難マップ
             </button>
             <button
               onClick={() => setCurrentView('route')}
-              className={`${
-                currentView === 'route'
-                  ? 'border-indigo-500 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
+              className={`${currentView === 'route'
+                ? 'border-indigo-500 text-gray-900'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
             >
               避難経路
             </button>
             <button
               onClick={() => setCurrentView('contacts')}
-              className={`${
-                currentView === 'contacts'
-                  ? 'border-indigo-500 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
+              className={`${currentView === 'contacts'
+                ? 'border-indigo-500 text-gray-900'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
             >
               緊急連絡先
             </button>
           </nav>
         </div>
       </div>
+
+      {/* 調整中メッセージ */}
+      {isAdjusting && (
+        <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
+          現在調整中のため、不具合が出る場合があります
+        </div>
+      )}
 
       {/* メインコンテンツ */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">

--- a/app/map/components/Map.js
+++ b/app/map/components/Map.js
@@ -25,6 +25,14 @@ export default function Map({ center, onShelterSelect }) {
 
   // Supabaseから避難所データを読み込む
   const loadSheltersFromSupabase = useCallback(async () => {
+    // mapInstance.current がなければリトライ
+    if (!mapInstance.current) {
+      console.error('Map instance is not available for adding shelters');
+      // 500ms後に再度試行
+      setTimeout(loadSheltersFromSupabase, 500);
+      return;
+    }
+
     try {
       const { data: shelters, error } = await supabase
         .from('shelters')

--- a/app/stock/page.js
+++ b/app/stock/page.js
@@ -1,5 +1,33 @@
-import DefaltPage from "@/app/stock/components/DefaultPage"
+"use client";
 
-export default function Page(){
-  return <DefaltPage />;
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import DefaultPage from "@/app/stock/components/DefaultPage";
+
+export default function StockPage() {
+  const [isAdjusting, setIsAdjusting] = useState(false);
+
+  useEffect(() => {
+    // Supabaseから調整中状態を取得
+    const fetchAdjusting = async () => {
+      const { data, error } = await supabase
+        .from("ui_adjusting")
+        .select("is_adjusting")
+        .eq("screen", "stock")
+        .single();
+      if (!error && data) setIsAdjusting(data.is_adjusting);
+    };
+    fetchAdjusting();
+  }, []);
+
+  return (
+    <div>
+      {isAdjusting && (
+        <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
+          現在調整中のため、不具合が出る場合があります
+        </div>
+      )}
+      <DefaultPage />
+    </div>
+  );
 }


### PR DESCRIPTION
## 🔧 概要（機能名 / 画面名）
通知・アラート画面に「UI調整中」警告表示機能を追加

## 📄 対象ページ・ファイル
- パス: `/alert`
- 主要ファイル: `app/alert/page.js`

## 🧾 実装による変化

### Before（任意）
- 「UI調整中」状態に関する警告表示がなかった

### After（変更点）
- Supabaseの`ui_adjusting`テーブルから`is_adjusting`状態を取得し、調整中の場合は警告メッセージを表示するように変更

## 🧪 動作確認項目
- [ ] Supabaseで`ui_adjusting`の`screen`が`alert`の`is_adjusting`が`true`の場合、警告が表示される
- [ ] 通常時は警告が表示されない
- [ ] エラー・警告が発生しない

## 🔍 今後の修正必要性（任意）
- 緊急度: 低  
- 他画面との共通化やリファクタリングの検討余地あり

## 📝 その他メモ（任意）
- `eq('screen', 'evacuation')` → `eq('screen', 'alert')` への修正が必要
- 他画面（evacuation, stock）も同様の仕組みで統一可能